### PR TITLE
Move away from hard-coded machine name

### DIFF
--- a/files/machine_provision.yml
+++ b/files/machine_provision.yml
@@ -74,54 +74,23 @@
                  - shell: |
                         #!/bin/bash
                         set -ex
-                        if [ "${machine_type}" == "d03" ]; then
-                                kernel_opts="${kernel_opts} earlycon console=ttyS0,115200"
-                                if [ "${job_type}" == "benchmark" ]; then
-                                        machine_name="hpc-d03-04"
-                                        machine_arch=AArch64
-                                        machine_subarch=Grub
-                                elif [ "${job_type}" == "openhpc" ]; then
-                                        machine_name="hpc-d03-01"
-                                        machine_arch=AArch64
-                                        machine_subarch=Grub
 
-                                fi
-                        elif [ "${machine_type}" == "d05" ]; then
-                                kernel_opts="${kernel_opts} earlycon console=ttyAMA0,115200"
-                                if [ "${job_type}" == "benchmark" ]; then
-                                        machine_name="hpc-d05-02"
-                                        machine_arch=AArch64
-                                        machine_subarch=Grub
-                                elif [ "${job_type}" == "openhpc" ]; then
-                                        machine_name="hpc-d05-01"
-                                        machine_arch=AArch64
-                                        machine_subarch=Grub
-                                fi
+                        # Defaults
+                        machine_name="hpc-${machine_type}-${job_type}"
+                        machine_arch=AArch64
+                        machine_subarch=Grub
+                        kernel_opts="${kernel_opts} earlycon console=ttyAMA0,115200"
+
+                        # Special cases
+                        if [ "${machine_type}" == "d03" ]; then
+                            kernel_opts="${kernel_opts} earlycon console=ttyS0,115200"
+
                         elif [ "${machine_type}" == "qdc" ]; then
-                                kernel_opts="${kernel_opts} earlycon console=ttyAMA0,115200"
-                                if [ "${job_type}" == "benchmark" ]; then
-                                        machine_name="hpc-qdc-05"
-                                        machine_arch=AArch64
-                                        machine_subarch=GrubWithOptionEfiboot
-                                elif [ "${job_type}" == "openhpc" ]; then
-                                        machine_name="hpc-qdc-02"
-                                        machine_arch=AArch64
-                                        machine_subarch=GrubWithOptionEfiboot
-                                fi
-                        elif [ "${machine_type}" == "tx2" ]; then
-                                kernel_opts="${kernel_opts} earlycon console=ttyAMA0,115200"
-                                if [ "${job_type}" == "benchmark" ]; then
-                                        machine_name="hpc-tx2-01"
-                                        machine_arch=AArch64
-                                        machine_subarch=Grub
-                                elif [ "${job_type}" == "openhpc" ]; then
-                                        machine_name="hpc-tx2-01"
-                                        machine_arch=AArch64
-                                        machine_subarch=Grub
-                                fi
-                        else
-                                echo "Machine Type does not exist...."
+                            machine_subarch=GrubWithOptionEfiboot
+
                         fi
+
+                        # Build trigger file
                         cat << EOF > mrp_provision
                         node="jslave-${machine_type}-${job_type}"
                         machine_name=${machine_name}


### PR DESCRIPTION
Adding more architecture types or moving machine around was starting to
take its toll on how often we reconfigure the jenkins scripts. This
change decouples which physical machine actually runs the jobs and makes
sure that only a provisioner change (machine name) is needed to relocate
resources to the right place.