### PR TITLE
Benchmark Ansible Job support

### DIFF
--- a/files/benchmark_job.yml
+++ b/files/benchmark_job.yml
@@ -44,6 +44,7 @@
                          description: 'The MrP type of the machine to be provisioned'
                  - string:
                          name: ip
+                         default: ''
                          description: 'The IP of the machine'
                  - choice:
                          name: branch
@@ -66,18 +67,43 @@
                                  - clang
                          default: 'gcc'
                          description: 'The compiler with which to compile the benchmark'
+                 - string:
+                         name: compiler_flags
+                         default: ''
+                         description: 'The extra compiler flags to compiler with'
+                 - string:
+                         name: link_flags
+                         default: ''
+                         description: 'The extra linker flags to link with'
+                 - string:
+                         name: benchmark_options
+                         default: ''
+                         description: 'The benchmark options to run the benchmark with'
+                 - string:
+                         name: benchmark_build_deps
+                         default: ''
+                         description: 'The extra benchmark specific build deps'
+                 - string:
+                         name: benchmark_run_deps
+                         default: ''
+                         description: 'The extra benchmark specific run deps'
          builders:
                  - shell: |
                         #!/bin/bash
                         set -ex
-                        
-                        SSH_FLAGS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
-                        ssh ${SSH_FLAGS} root@${ip} "echo '2' | tee  /proc/sys/kernel/perf_event_paranoid"
-                        ssh ${SSH_FLAGS} root@${ip} "apt update ; apt install -y python3 python3-pip git build-essential linux-perf"
-                        if ssh ${SSH_FLAGS} root@${ip} '[ ! -d benchmark_harness ]' ; then
-                                ssh ${SSH_FLAGS} root@${ip} git clone -b ${branch} https://github.com/BaptisteGerondeau/benchmark_harness.git
-                        else
-                                ssh ${SSH_FLAGS} root@${ip} "git -C benchmark_harness pull ; git -C benchmark_harness checkout ${branch}"
-                        fi
-                        ssh ${SSH_FLAGS} root@${ip} pip3 install -r benchmark_harness/requirements.txt
-                        ssh ${SSH_FLAGS} root@${ip} "cd benchmark_harness ; ./benchmark_controller.py ${benchmark} ${machine_type} ${compiler} --compiler-flags="${compiler_flags}" --link-flags="${link_flags}" --benchmark-options="${benchmark_options}" --benchmark-build-deps="${benchmark_build_deps}" --benchmark-run-deps="${benchmark_run_deps}" --benchmark-root="/tmp/" -v"
+                        cat << EOF > benchmark_job.yml
+                        mr_provisioner_url: http://10.40.0.11:5000
+                        mr_provisioner_token: $(cat "/home/${NODE_NAME}/mrp_token")
+                        mr_provisioner_machine_name: hpc-${machine_type}-benchmark
+                        branch: ${branch}
+                        benchmark: ${benchmark}
+                        machine_type: ${machine_type}
+                        compiler: ${compiler}
+                        compiler_flags: ${compiler_flags}
+                        link_flags: ${link_flags}
+                        benchmark_options: ${benchmark_options}
+                        benchmark_build_deps: ${benchmark_build_deps}
+                        benchmark_run_deps: ${benchmark_run_deps}
+                        EOF
+
+                        ansible-playbook /etc/ansible/roles/hpc_deploy_benchmarks/hpc_deploy_benchmarks.yml --extra-vars="@benchmark_job.yml" 

--- a/tasks/create_slaves.yml
+++ b/tasks/create_slaves.yml
@@ -8,12 +8,23 @@
           group: "jenkins_slave"
   with_list: "{{ jslave_list }}"
 
-- name: Slurp up the ssh_keys
+- name: Fetch the ssh_keys from the remote
   fetch:
       src: "/home/{{ item }}/.ssh/id_rsa.pub"
-      dest: "/tmp/{{ item }}.sshkey"
+      dest: "./{{ item }}.sshkey"
       flat: yes
   with_list: "{{ jslave_list }}"
+
+- name: Putting the keys into the template for the fileserver
+  template:
+    src: templates/jslaves.yml.j2
+    dest: /tmp/jslaves.yml
+
+- name: Get the template back
+  fetch:
+    src: /tmp/jslaves.yml
+    dest: ./
+    flat: yes
 
 - name: Add Master Jenkins' ssh key to the slaves authorized list
   authorized_key:
@@ -26,7 +37,7 @@
   authorized_key:
           user: "{{ item }}"
           state: present
-          key: "{{ lookup('file', '/tmp/{{ item }}.sshkey') }}"
+          key: "{{ lookup('file', './{{ item }}.sshkey') }}"
   with_list: "{{ jslave_list }}"
 
 - name: Copy the playbook maker script to their home dir

--- a/templates/jslaves.yml.j2
+++ b/templates/jslaves.yml.j2
@@ -1,0 +1,14 @@
+---
+jslaves:
+{% for item in jslave_list|select("match", ".*benchmark.*") %}
+    - name: {{ item }}
+{% if item is match(".*qdc.*") %}
+      cgroup: qualcomm
+{% elif item is match(".*d0.*") %}
+      cgroup: huawei
+{% elif item is match(".*tx.*") %}
+      cgroup: cavium
+{% endif %}
+      ssh_key: {% include '%s.sshkey' % item %}
+
+{% endfor %}


### PR DESCRIPTION
This adds support for the benchmark install and Ansible run job, as well as some preparation for the setup of the fileserver, namely extracting the jslaves' sshkeys to feed them back to the sftp server.