### PR TITLE
Revert "Added Test job for OpenHPC install quick validation"

### DIFF
--- a/files/ohpc_install.yml
+++ b/files/ohpc_install.yml
@@ -220,6 +220,4 @@
 
                         cd ansible-playbook-for-ohpc
                         ansible-playbook site.yml --extra-vars="@../ohpc_installation.yml" -i ../hosts
-
-                        ssh root@${master_ip} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "useradd -m test ; pdsh -w ${compute_regex} useradd -m test ; su - test ; mpicc -O3 /opt/ohpc/pub/examples/mpi/hello.c ; srun -n 8 -N 3 /home/test/a.out"
                         ssh-agent -k 


### PR DESCRIPTION
Reverts Linaro/hpc_lab_jenkins#33

It's not working on all clusters because pdsh uses rsh and not ssh, so we have to work around environments etc. Since we'll create a test-suite job later, which will have all the environment setup, we should move this logic in there, later.