### PR TITLE
Change hostnames to have no dashes or underscores

### DIFF
--- a/files/benchmark_job.yml
+++ b/files/benchmark_job.yml
@@ -104,7 +104,7 @@
                         cat << EOF > benchmark_job.yml
                         mr_provisioner_url: http://10.40.0.11:5000
                         mr_provisioner_token: $(cat "/home/${NODE_NAME}/mrp_token")
-                        mr_provisioner_machine_name: hpc-${machine_type}-benchmark
+                        mr_provisioner_machine_name: ${machine_type}bench
                         sftp_dirname: ${machine_type}-${BUILD_NUMBER}
                         sftp_user: ${NODE_NAME}
                         sftp_server_ip: 10.40.0.13

--- a/files/cluster_provision.yml
+++ b/files/cluster_provision.yml
@@ -43,14 +43,14 @@
                         set -ex
 
                         if [ ${machine_type} == "qdc" ]; then
-                                machine_list="hpc-qdc-openhpc, hpc-qdc-compute-01, hpc-qdc-compute-02, hpc-qdc-compute-03"
+                                machine_list="qdcohpc, qdc01, qdc02, qdc03"
                                 preseed_type="kickstart"
                                 kernel_desc="CentOS 7.5"
                                 initrd_desc="CentOS 7.5"
                                 preseed_name="CentOS Upstream"
                                 kernel_opts="ip=dhcp text inst.stage2=http://mirror.centos.org/altarch/7/os/aarch64/ inst.repo=http://mirror.centos.org/altarch/7/os/aarch64/ inst.ks=file:/ks.cfg"
                         elif [ ${machine_type} == "d05" ]; then
-                                machine_list="hpc-d05-openhpc, hpc-d03-compute-01, hpc-d03-compute-02, hpc-d03-compute-03"
+                                machine_list="d05ohpc, d0301, d0302, d0303"
                                 preseed_type="kickstart"
                                 kernel_desc="CentOS ERP 119"
                                 initrd_desc="CentOS ERP 119"

--- a/files/machine_provision.yml
+++ b/files/machine_provision.yml
@@ -40,7 +40,7 @@
                          description: 'The list of the MrP names of the machine_subarch to provision'
                  - string:
                          name: job_type
-                         default: 'benchmark'
+                         default: 'bench'
                          description: 'The job type you will execute on the machine'
                  - string:
                          name: os_type
@@ -85,7 +85,7 @@
 
                         # Defaults
                         if [[ ${machine_list} == '' ]]; then
-                                machine_name="hpc-${machine_type}-${job_type}"
+                                machine_name="${machine_type}${job_type}"
                         else
                                 machine_list="$( echo "$machine_list"| tr -d '[:space:]')"
                                 machine_name=${machine_list}

--- a/files/ohpc_install.yml
+++ b/files/ohpc_install.yml
@@ -72,41 +72,41 @@
                         mr_provisioner_token=$(cat "/home/${NODE_NAME}/mrp_token")
 
                         if [ ${cluster} == 'qualcomm' ]; then
-                                master_name='hpc_qdc_openhpc'
-                                cnode01='hpc_qdc_compute01'
-                                cnode02='hpc_qdc_compute02'
-                                cnode03='hpc_qdc_compute03'
+                                master_name='qdcohpc'
+                                cnode01='qdc01'
+                                cnode02='qdc02'
+                                cnode03='qdc03'
                                 master_eth_internal='eth0'
                                 eth_provision='eth0'
                                 num_compute='3'
-                                master_ip=$( ./mr-provisioner-client/mrp_client.py getip hpc-qdc-openhpc --mrp-url=${mr_provisioner_url} --mrp-token=${mr_provisioner_token})
-                                cnode01ip=$( ./mr-provisioner-client/mrp_client.py getip hpc-qdc-compute-01 --mrp-url=${mr_provisioner_url} --mrp-token=${mr_provisioner_token})
-                                cnode01mac=$( ./mr-provisioner-client/mrp_client.py getmac hpc-qdc-compute-01 --mrp-url=${mr_provisioner_url} --mrp-token=${mr_provisioner_token})
-                                cnode02ip=$( ./mr-provisioner-client/mrp_client.py getip hpc-qdc-compute-02 --mrp-url=${mr_provisioner_url} --mrp-token=${mr_provisioner_token})
-                                cnode02mac=$( ./mr-provisioner-client/mrp_client.py getmac hpc-qdc-compute-02 --mrp-url=${mr_provisioner_url} --mrp-token=${mr_provisioner_token})
-                                cnode03ip=$( ./mr-provisioner-client/mrp_client.py getip hpc-qdc-compute-03 --mrp-url=${mr_provisioner_url} --mrp-token=${mr_provisioner_token})
-                                cnode03mac=$( ./mr-provisioner-client/mrp_client.py getmac hpc-qdc-compute-03 --mrp-url=${mr_provisioner_url} --mrp-token=${mr_provisioner_token})
-                                compute_prefix='hpc_qdc_compute0'
-                                compute_regex='hpc_qdc_compute0[1-3]'
+                                master_ip=$( ./mr-provisioner-client/mrp_client.py getip qdcohpc --mrp-url=${mr_provisioner_url} --mrp-token=${mr_provisioner_token})
+                                cnode01ip=$( ./mr-provisioner-client/mrp_client.py getip qdc01 --mrp-url=${mr_provisioner_url} --mrp-token=${mr_provisioner_token})
+                                cnode01mac=$( ./mr-provisioner-client/mrp_client.py getmac qdc01 --mrp-url=${mr_provisioner_url} --mrp-token=${mr_provisioner_token})
+                                cnode02ip=$( ./mr-provisioner-client/mrp_client.py getip qdc02 --mrp-url=${mr_provisioner_url} --mrp-token=${mr_provisioner_token})
+                                cnode02mac=$( ./mr-provisioner-client/mrp_client.py getmac qdc02 --mrp-url=${mr_provisioner_url} --mrp-token=${mr_provisioner_token})
+                                cnode03ip=$( ./mr-provisioner-client/mrp_client.py getip qdc03 --mrp-url=${mr_provisioner_url} --mrp-token=${mr_provisioner_token})
+                                cnode03mac=$( ./mr-provisioner-client/mrp_client.py getmac qdc03 --mrp-url=${mr_provisioner_url} --mrp-token=${mr_provisioner_token})
+                                compute_prefix='qdc0'
+                                compute_regex='qdc0[1-3]'
                                 kargs=''
                                 additional_modules='qcom_emac'
                         elif [ ${cluster} == 'huawei' ]; then
-                                master_name='hpc_d05_openhpc'
-                                cnode01='hpc_d03_compute01'
-                                cnode02='hpc_d03_compute02'
-                                cnode03='hpc_d03_compute03'
+                                master_name='d05ohpc'
+                                cnode01='d0301'
+                                cnode02='d0302'
+                                cnode03='d0303'
                                 master_eth_internal='enahisic2i1'
                                 eth_provision='enahisic2i1'
                                 num_compute='3' 
-                                master_ip=$( ./mr-provisioner-client/mrp_client.py getip hpc-d05-openhpc --mrp-url=${mr_provisioner_url} --mrp-token=${mr_provisioner_token})
-                                cnode01ip=$( ./mr-provisioner-client/mrp_client.py getip hpc-d03-compute-01 --mrp-url=${mr_provisioner_url} --mrp-token=${mr_provisioner_token})
-                                cnode01mac=$( ./mr-provisioner-client/mrp_client.py getmac hpc-d03-compute-01 --mrp-url=${mr_provisioner_url} --mrp-token=${mr_provisioner_token})
-                                cnode02ip=$( ./mr-provisioner-client/mrp_client.py getip hpc-d03-compute-02 --mrp-url=${mr_provisioner_url} --mrp-token=${mr_provisioner_token})
-                                cnode02mac=$( ./mr-provisioner-client/mrp_client.py getmac hpc-d03-compute-02 --mrp-url=${mr_provisioner_url} --mrp-token=${mr_provisioner_token})
-                                cnode03ip=$( ./mr-provisioner-client/mrp_client.py getip hpc-d03-compute-03 --mrp-url=${mr_provisioner_url} --mrp-token=${mr_provisioner_token})
-                                cnode03mac=$( ./mr-provisioner-client/mrp_client.py getmac hpc-d03-compute-03 --mrp-url=${mr_provisioner_url} --mrp-token=${mr_provisioner_token})
-                                compute_prefix='hpc_d03_compute0'
-                                compute_regex='hpc_d03_compute0[1-3]'
+                                master_ip=$( ./mr-provisioner-client/mrp_client.py getip d05ohpc --mrp-url=${mr_provisioner_url} --mrp-token=${mr_provisioner_token})
+                                cnode01ip=$( ./mr-provisioner-client/mrp_client.py getip d0301 --mrp-url=${mr_provisioner_url} --mrp-token=${mr_provisioner_token})
+                                cnode01mac=$( ./mr-provisioner-client/mrp_client.py getmac d0301 --mrp-url=${mr_provisioner_url} --mrp-token=${mr_provisioner_token})
+                                cnode02ip=$( ./mr-provisioner-client/mrp_client.py getip d0302 --mrp-url=${mr_provisioner_url} --mrp-token=${mr_provisioner_token})
+                                cnode02mac=$( ./mr-provisioner-client/mrp_client.py getmac d0302 --mrp-url=${mr_provisioner_url} --mrp-token=${mr_provisioner_token})
+                                cnode03ip=$( ./mr-provisioner-client/mrp_client.py getip d0303 --mrp-url=${mr_provisioner_url} --mrp-token=${mr_provisioner_token})
+                                cnode03mac=$( ./mr-provisioner-client/mrp_client.py getmac d0303 --mrp-url=${mr_provisioner_url} --mrp-token=${mr_provisioner_token})
+                                compute_prefix='d030'
+                                compute_regex='d030[1-3]'
                                 kargs=''
                         fi
 

--- a/files/ohpc_test_suite.yml
+++ b/files/ohpc_test_suite.yml
@@ -68,27 +68,27 @@
                         mr_provisioner_token=$(cat "/home/${NODE_NAME}/mrp_token")
 
                         if [ ${cluster} == 'qualcomm' ]; then
-                                master_name='hpc_qdc_openhpc'
-                                cnode01='hpc_qdc_compute01'
-                                cnode02='hpc_qdc_compute02'
-                                cnode03='hpc_qdc_compute03'
+                                master_name='qdcohpc'
+                                cnode01='qdc01'
+                                cnode02='qdc02'
+                                cnode03='qdc03'
                                 num_compute='3'
-                                master_ip=$( ./mr-provisioner-client/mrp_client.py getip hpc-qdc-openhpc --mrp-url=${mr_provisioner_url} --mrp-token=${mr_provisioner_token})
-                                cnode01ip=$( ./mr-provisioner-client/mrp_client.py getip hpc-qdc-compute-01 --mrp-url=${mr_provisioner_url} --mrp-token=${mr_provisioner_token})
-                                cnode02ip=$( ./mr-provisioner-client/mrp_client.py getip hpc-qdc-compute-02 --mrp-url=${mr_provisioner_url} --mrp-token=${mr_provisioner_token})
-                                cnode03ip=$( ./mr-provisioner-client/mrp_client.py getip hpc-qdc-compute-03 --mrp-url=${mr_provisioner_url} --mrp-token=${mr_provisioner_token})
-                                compute_regex='hpc_qdc_compute0[1-3]'
+                                master_ip=$( ./mr-provisioner-client/mrp_client.py getip qdcohpc --mrp-url=${mr_provisioner_url} --mrp-token=${mr_provisioner_token})
+                                cnode01ip=$( ./mr-provisioner-client/mrp_client.py getip qdc01 --mrp-url=${mr_provisioner_url} --mrp-token=${mr_provisioner_token})
+                                cnode02ip=$( ./mr-provisioner-client/mrp_client.py getip qdc02 --mrp-url=${mr_provisioner_url} --mrp-token=${mr_provisioner_token})
+                                cnode03ip=$( ./mr-provisioner-client/mrp_client.py getip qdc03 --mrp-url=${mr_provisioner_url} --mrp-token=${mr_provisioner_token})
+                                compute_regex='qdc0[1-3]'
                         elif [ ${cluster} == 'huawei' ]; then
-                                master_name='hpc_d05_openhpc'
-                                cnode01='hpc_d03_compute01'
-                                cnode02='hpc_d03_compute02'
-                                cnode03='hpc_d03_compute03'
+                                master_name='d05ohpc'
+                                cnode01='d0301'
+                                cnode02='d0302'
+                                cnode03='d0303'
                                 num_compute='3' 
-                                master_ip=$( ./mr-provisioner-client/mrp_client.py getip hpc-d05-openhpc --mrp-url=${mr_provisioner_url} --mrp-token=${mr_provisioner_token})
-                                cnode01ip=$( ./mr-provisioner-client/mrp_client.py getip hpc-d03-compute-01 --mrp-url=${mr_provisioner_url} --mrp-token=${mr_provisioner_token})
-                                cnode02ip=$( ./mr-provisioner-client/mrp_client.py getip hpc-d03-compute-02 --mrp-url=${mr_provisioner_url} --mrp-token=${mr_provisioner_token})
-                                cnode03ip=$( ./mr-provisioner-client/mrp_client.py getip hpc-d03-compute-03 --mrp-url=${mr_provisioner_url} --mrp-token=${mr_provisioner_token})
-                                compute_regex='hpc_d03_compute0[1-3]'
+                                master_ip=$( ./mr-provisioner-client/mrp_client.py getip d05ohpc --mrp-url=${mr_provisioner_url} --mrp-token=${mr_provisioner_token})
+                                cnode01ip=$( ./mr-provisioner-client/mrp_client.py getip d0301 --mrp-url=${mr_provisioner_url} --mrp-token=${mr_provisioner_token})
+                                cnode02ip=$( ./mr-provisioner-client/mrp_client.py getip d0302 --mrp-url=${mr_provisioner_url} --mrp-token=${mr_provisioner_token})
+                                cnode03ip=$( ./mr-provisioner-client/mrp_client.py getip d0303 --mrp-url=${mr_provisioner_url} --mrp-token=${mr_provisioner_token})
+                                compute_regex='d030[1-3]'
                         fi
 
                         if [ ${method} == 'stateful' ]; then

--- a/files/os_provision.yml
+++ b/files/os_provision.yml
@@ -41,9 +41,9 @@
                  - choice:
                          name: job_type
                          choices:
-                                 - benchmark
-                                 - openhpc
-                         default: 'benchmark'
+                                 - bench
+                                 - ohpc
+                         default: 'bench'
                          description: 'The job type you will execute on the machine'
                  - choice:
                          name: os_type

--- a/files/preseeds/Centos-Upstream.kickstart
+++ b/files/preseeds/Centos-Upstream.kickstart
@@ -1,11 +1,5 @@
 # Required Kernel options to install ERP CentOS7 build: 
 # ip=dhcp text inst.stage2=http://mirror.centos.org/altarch/7/os/aarch64/ inst.repo=http://mirror.centos.org/altarch/7/os/aarch64/ inst.ks=file:/ks.cfg
-%pre
-#!/bin/bash
-old_hostname={{ hostname }}
-host_name=$(echo "$old_hostname"| tr - _| sed -r 's/e_0/e0/g')
-echo "network --hostname=$host_name" > /tmp/hostname.ks
-%end
 # Use network installation
 url --url="http://mirror.centos.org/altarch/7/os/aarch64/" --proxy=http://10.40.0.13:3142
 repo --name="upstream" --baseurl=http://mirrors.coreix.net/centos-altarch/ --proxy=http://10.40.0.13:3142
@@ -24,8 +18,8 @@ timezone Europe/London
 rootpw --iscrypted !!
 
 # Network information
-network  --bootproto=dhcp
-%include "/tmp/hostname.ks"
+network --bootproto=dhcp
+network --hostname={{hostname}}
 
 # System services
 services --enabled="chronyd"

--- a/files/preseeds/Centos.kickstart
+++ b/files/preseeds/Centos.kickstart
@@ -1,11 +1,5 @@
 # Required Kernel options to install ERP CentOS7 build: 
 # ip=dhcp text inst.stage2=http://snapshots.linaro.org/96boards/reference-platform/components/centos-installer/119/ inst.repo=http://mirror.centos.org/altarch/7/os/aarch64/ inst.ks=file:/ks.cfg
-%pre
-#!/bin/bash
-old_hostname={{ hostname }}
-host_name=$(echo "$old_hostname"| tr - _| sed -r 's/e_0/e0/g')
-echo "network --hostname=$host_name" > /tmp/hostname.ks
-%end
 # Use network installation
 url --url="http://mirror.centos.org/altarch/7/os/aarch64/" --proxy=http://10.40.0.13:3142
 repo --name="ERP-RPM:staging" --baseurl=http://obs.linaro.org/ERP-RPM:/18.06/stable/ --proxy=http://10.40.0.13:3142
@@ -24,8 +18,8 @@ timezone Europe/London
 rootpw --iscrypted !!
 
 # Network information
-network  --bootproto=dhcp
-%include "/tmp/hostname.ks"
+network --bootproto=dhcp
+network --hostname={{hostname}}
 
 # System services
 services --enabled="chronyd"


### PR DESCRIPTION
Some preseed/kickstart logic don't like one while slurm doesn't like the
other. We may revisit this in the future, but right now, we need to
worry about the core functionality which is to predictably deploy
OpenHPC clusters and run the test suite unimpeded by silly
implementations of the RFC.